### PR TITLE
update-pr-spreadsheet.yml: reusable workflow now handles its input data

### DIFF
--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -1,30 +1,15 @@
 name: PR Event Workflow
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, edited, closed, synchronize, assigned, unassigned, review_requested, review_request_removed]
   pull_request_review:
     types: [submitted, edited, dismissed]
   issue_comment:
     types: [created, edited, deleted]
+
 jobs:
   call-update-spreadsheet:
     uses: learningequality/.github/.github/workflows/update-pr-spreadsheet.yml@main
-    with:
-      pr_data: |
-        {
-          "merged_at": "${{ github.event.pull_request.merged_at }}",
-          "html_url": "${{ github.event.pull_request.html_url }}",
-          "user_login": "${{ github.event.pull_request.user.login }}",
-          "title": "${{ github.event.pull_request.title }}",
-          "repo_name": "${{ github.event.pull_request.base.repo.name }}",
-          "updated_at": "${{ github.event.pull_request.updated_at }}",
-          "requested_reviewers": "${{ join(github.event.pull_request.requested_reviewers.*.login, ',') }}",
-          "assignees": "${{ join(github.event.pull_request.assignees.*.login, ',') }}",
-          "user_site_admin": ${{ github.event.pull_request.user.site_admin }},
-          "user_type": "${{ github.event.pull_request.user.type }}",
-          "author_association": "${{ github.event.pull_request.author_association }}",
-          "state": "${{ github.event.pull_request.state }}"
-        }
     secrets:
       CONTRIBUTIONS_SPREADSHEET_ID: ${{ secrets.CONTRIBUTIONS_SPREADSHEET_ID }}
       CONTRIBUTIONS_SHEET_NAME: ${{ secrets.CONTRIBUTIONS_SHEET_NAME }}


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
- Removes JSON input field, which the reusable workflow no longer accepts because it uses the GH event data directly

## References
<!-- Any additional notes you'd like to add -->
corresponds to https://github.com/learningequality/.github/pull/4
