### PR TITLE
Enhance Slack notifications and automate GitHub assignment replies based on issue labels

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   contributor_issue_comment:
-    uses: learningequality/.github/.github/workflows/notify_team_new_comment.yml@main
+    uses: testiamshobh/.github/.github/workflows/notify_team_new_comment.yml@main
     secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL }}

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   contributor_issue_comment:
-    uses: testiamshobh/.github/.github/workflows/notify_team_new_comment.yml@main
+    uses: learningequality/.github/.github/workflows/notify_team_new_comment.yml@main
     secrets:
       LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
       LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Updated the existing `notify_team_new_comment` workflow.
This update adds the following steps :-  

1.  distinguish comments on  "help wanted" and "non help wanted" labelled issues and based on the label, send notification to a slack channel.
2. In "Non help wanted" labelled issues, send a bot reply if the comment by external users contains a certain keyword while ensuring that there was no bot message sent in past hour on that issue.
3.  "Help wanted" labelled issues work just like before.

I've tested this by creating a testing environment.  

## References

addresse issue  [#23](https://github.com/learningequality/.github/issues/23)
